### PR TITLE
Check if currAnime episodes is not null (ongoing shows)

### DIFF
--- a/lib/anilist.js
+++ b/lib/anilist.js
@@ -53,7 +53,7 @@ async function updateAnilist(id, currentEpisode) {
   const currProgress = currAnime.mediaListEntry
     ? currAnime.mediaListEntry.progress
     : 0;
-  if (currProgress >= currentEpisode || currentEpisode > currAnime.episodes)
+  if (currProgress >= currentEpisode || (currAnime.episodes != null && currentEpisode > currAnime.episodes))
     return;
 
   await anilistApi.lists.addEntry(id, {


### PR DESCRIPTION
Ongoing shows often have currAnime.episodes as null and this interferes with checks.